### PR TITLE
check _managerWidget ptr before using it.

### DIFF
--- a/src/manager/kwalletmanager.cpp
+++ b/src/manager/kwalletmanager.cpp
@@ -483,7 +483,7 @@ void KWalletManager::importWallets()
 
 bool KWalletManager::hasUnsavedChanges(const QString &name) const
 {
-    return _managerWidget->hasUnsavedChanges(name);
+    return (_managerWidget ? _managerWidget->hasUnsavedChanges(name) : false);
 }
 
 bool KWalletManager::canIgnoreUnsavedChanges()


### PR DESCRIPTION
Bug that crashes walletmanager5

This is good practice,

```
bool KWalletManagerWidgetItem::hasUnsavedChanges() const 
{ 
   return (_controlWidget ? _controlWidget->hasUnsavedChanges() : false); 
} 


```

but elsewhere similar needs to be done,

```
bool KWalletManager::hasUnsavedChanges(const QString &name) const 
{  
   return (_managerWidget ? _managerWidget→hasUnsavedChanges(name) : false); 
} 


```

The bug is easy to reproduce and always happens,

![image](https://github.com/user-attachments/assets/1e6189d8-178d-4c55-81bd-5eaf416a1285)


[kwalletmanager5-20240921-181328.kcrash.txt](https://github.com/user-attachments/files/17083840/kwalletmanager5-20240921-181328.kcrash.txt)
